### PR TITLE
Loosen react requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react": "^16.2.0"
+    "react": ">= 15 < 17"
   },
   "devDependencies": {
     "@storybook/addons": "^3.3.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,9 +6133,9 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+"react@>= 15 < 17":
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
react-svg-spinner works fine with 15, and I'd like to use it in a 15 context.